### PR TITLE
Update cards with additional requirement data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,5 @@ dist
 # End of https://www.toptal.com/developers/gitignore/api/node,vscode
 
 .DS_Store
+
+next.config.js

--- a/components/AirTableCard.js
+++ b/components/AirTableCard.js
@@ -30,6 +30,20 @@ const displayPhoneNumber = (phone) => {
   }
 };
 
+const getCommaSeparatedList = (items) => {
+  const lowercaseString = items.join(", ").trim().toLowerCase() + ' only';
+  return lowercaseString[0].toUpperCase() + lowercaseString.slice(1);
+}
+
+// These are all multi selects, so they'll either be null (no data) or an array
+const getOptionalAdditionalInfo = (additionalInfo) => {
+  if (additionalInfo) {
+    return getCommaSeparatedList(additionalInfo);
+  } else {
+    return null; 
+  }
+}
+
 function AvailabilityTag({ availabilityStatus, numReports }) {
   // TODO : Fix this ugly if-else block that I don't have time to address right now.
   switch (availabilityStatus.value) {
@@ -112,6 +126,18 @@ export default function AirTableCard({ location }) {
 
   const availabilityStatus = location.availabilityStatus;
 
+  const ageRequirement = getOptionalAdditionalInfo(location.fields.age_requirement);
+  const occupationRequirement = getOptionalAdditionalInfo(location.fields.occupation_requirement);
+  const countyRequirement = getOptionalAdditionalInfo(location.fields.eligible_counties);
+
+  // TODO: We could order these so that they are always in the same spot (e.g. age | occupation | location )
+  // but this would often mean empty sections on the left.
+  // If we want the data to always flow left to right, we could choose to leave out the null values in the below array.
+  // The tradeoff here is that data could end up in different locations depending on the specific card, which might
+  // make things harder to scan.
+  const allAdditionalRequirements = [ageRequirement, occupationRequirement, countyRequirement];
+  const additionalRequirementsToDisplay = allAdditionalRequirements.filter((req) => req != null);
+
   return (
     <>
       <div className="location-card card">
@@ -162,6 +188,21 @@ export default function AirTableCard({ location }) {
               numReports={location.fields["Number of reports"]}
             />
           </li>
+          { additionalRequirementsToDisplay.length > 0 && (
+            <li className="list-group-item py-0">
+              <div className="row additional-requirements">
+                {
+                  additionalRequirementsToDisplay.map((req) => {
+                    return (
+                      <div className="col-md-4 col-12 px-3 py-2 d-flex align-items-center" key={req}>
+                        {req}
+                      </div>
+                    );
+                  })
+                }
+              </div>
+            </li>
+          ) }
           {reportNotes.length > 0 ? (
             <li className="list-group-item">
               <span className="text-black">

--- a/components/CountySearch.js
+++ b/components/CountySearch.js
@@ -19,7 +19,7 @@ function CountySearchInput({
         }}
       />
       <style jsx>{`
-        #search-input input  {
+        #search-input input {
           font-size: 115%;
           width: 100%;
           border: none;

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,8 @@
+#### Description
+A short description of the change
+
+#### Tests
+- [ ] Test 1
+- [ ] Test 2 
+
+#### Screenshots

--- a/styles/global.css
+++ b/styles/global.css
@@ -3,3 +3,14 @@ body,
 #__next {
   height: 100%;
 }
+
+.additional-requirements div:not(:last-child) {
+  border-right: 1px solid #DEDEDE;
+}
+
+@media screen and (max-width: 767px) {
+  .additional-requirements div:not(:last-child) {
+    border: none;
+    border-bottom: 1px solid #DEDEDE;
+  }
+}


### PR DESCRIPTION
#### Description
Updates the location cards with the new additional requirement data:
1. Age
2. Occupation
3. Location

For wider screens, all data will be in a single row. For narrower screens, each piece of data will have its own row. This change is a noop for locations without any additional requirements.

Note my open question in the comments

#### Tests
- [x] Looks good on wide screens
- [x] Looks good on narrow screens
- [x] Looks good with all 3 data items
- [x] Looks good with just some data items
- [x] No changes for 0 data items
- [x] Looks good with overflow
- [x] Capitalization / comma formatting is correct when there are multiple options for a single piece of data

#### Screenshots

Mobile full data:
<img width="667" alt="Screen Shot 2021-02-18 at 8 55 29 PM" src="https://user-images.githubusercontent.com/3207842/108448095-1a960200-722f-11eb-9c34-2d72fa7ff8ea.png">

Desktop full data:
<img width="844" alt="Screen Shot 2021-02-18 at 8 55 24 PM" src="https://user-images.githubusercontent.com/3207842/108448103-1e298900-722f-11eb-86b0-5e333a2b24eb.png">

Mobile partial data:
<img width="476" alt="Screen Shot 2021-02-18 at 8 53 05 PM" src="https://user-images.githubusercontent.com/3207842/108448122-2681c400-722f-11eb-951d-2cc713ef5c53.png">

Desktop partial data:
<img width="840" alt="Screen Shot 2021-02-18 at 8 53 11 PM" src="https://user-images.githubusercontent.com/3207842/108448143-2da8d200-722f-11eb-93b6-5baa1bbe9723.png">

Overflow:
<img width="836" alt="Screen Shot 2021-02-18 at 9 04 48 PM" src="https://user-images.githubusercontent.com/3207842/108448163-37323a00-722f-11eb-9ef3-5d40a5b63d16.png">

No data:
<img width="911" alt="Screen Shot 2021-02-18 at 8 53 28 PM" src="https://user-images.githubusercontent.com/3207842/108448188-444f2900-722f-11eb-8c33-13719c6d808d.png">


