### PR TITLE
Update nav bar to light design

### DIFF
--- a/components/SiteNavbar.js
+++ b/components/SiteNavbar.js
@@ -1,10 +1,13 @@
-import Navbar from "react-bootstrap/Navbar";
-import Nav from "react-bootstrap/Nav";
+import { Nav, Navbar } from "react-bootstrap";
+import { useRouter } from 'next/router'
 import Link from "next/link";
 
 export default function SiteNavbar() {
+  const router = useRouter();
+  const pathName = router.asPath;
+
   return (
-    <Navbar bg="dark" variant="dark" expand="lg">
+    <Navbar expand="lg" className="border-bottom">
       <Link href="/">
         <Navbar.Brand href="/">
           <div>
@@ -21,8 +24,8 @@ export default function SiteNavbar() {
         </Navbar.Brand>
       </Link>
       <Navbar.Toggle aria-controls="basic-navbar-nav" />
-      <Navbar.Collapse id="basic-navbar-nav">
-        <Nav className="mr-auto">
+      <Navbar.Collapse className="justify-content-end" id="basic-navbar-nav">
+        <Nav variant="pills" activeKey={pathName}>
           <Link href="/">
             <Nav.Link href="/">County Search</Nav.Link>
           </Link>

--- a/styles/global.css
+++ b/styles/global.css
@@ -8,9 +8,21 @@ body,
   border-right: 1px solid #dedede;
 }
 
+.nav-pills .active {
+  background-color: #F3F4F6 !important;
+  color: #7F7F7F !important;
+}
+
 @media screen and (max-width: 767px) {
   .requirements div:not(:last-child) {
     border: none;
     border-bottom: 1px solid #dedede;
+  }
+}
+
+@media screen and (max-width: 992px) {
+  .nav-pills > a {
+    padding-left: 8px !important;
+    padding-right: 8px !important;
   }
 }


### PR DESCRIPTION
#### Description
Made some updates to the nav bar to better align with the other homepage changes, the light design of the site, and the CA site.

#### Tests
- [x] Looks good on desktop
- [x] Looks good on mobile
- [x] Active works as expected

#### Screenshots

Overall:
<img width="1162" alt="Screen Shot 2021-02-19 at 12 01 09 AM" src="https://user-images.githubusercontent.com/3207842/108459965-9d29bc00-7245-11eb-8576-f73259f680d6.png">


Desktop:
<img width="1126" alt="Screen Shot 2021-02-18 at 11 50 32 PM" src="https://user-images.githubusercontent.com/3207842/108459143-19230480-7244-11eb-8f4c-630ad48c7fb8.png">

Mobile:
<img width="608" alt="Screen Shot 2021-02-18 at 11 41 29 PM" src="https://user-images.githubusercontent.com/3207842/108459117-0dcfd900-7244-11eb-9e1a-1c993521061d.png">
