### PR TITLE
Add county specific info links to the counties

### DIFF
--- a/pages/counties/[county].js
+++ b/pages/counties/[county].js
@@ -3,242 +3,231 @@ import counties from "../../content/counties";
 import CountyPageLayout from "../../layouts/CountyPageLayout";
 import { getCountyLocations, getCountySpecificInfo } from "../../utils/Data";
 import {
-    FaCheckCircle,
-    FaTimesCircle,
-    FaQuestionCircle,
-    FaArrowLeft,
-    FaClipboardList,
-    FaExternalLinkAlt,
+  FaCheckCircle,
+  FaTimesCircle,
+  FaQuestionCircle,
+  FaArrowLeft,
+  FaClipboardList,
+  FaExternalLinkAlt,
 } from "react-icons/fa";
 import moment from "moment";
 import Link from "next/link";
 
 function titleCase(str) {
-    return str.replace(/(^|\s)\S/g, function (t) {
-        return t.toUpperCase();
-    });
+  return str.replace(/(^|\s)\S/g, function (t) {
+    return t.toUpperCase();
+  });
 }
 
 function LocationGroup({ locationGroup }) {
-    return locationGroup.locations.length > 0 ? (
-        <div>
-            <h4
-                className={
-                    locationGroup.messageColor + " font-weight-bold mt-3"
-                }
-            >
-                {locationGroup.messageIcon}{" "}
-                <span className="align-middle">{locationGroup.message}</span>
-            </h4>
-            {locationGroup.locations.map((location) => (
-                <div key={location.id} className="my-3">
-                    <AirTableCard location={location} />
-                </div>
-            ))}
+  return locationGroup.locations.length > 0 ? (
+    <div>
+      <h4 className={locationGroup.messageColor + " font-weight-bold mt-3"}>
+        {locationGroup.messageIcon}{" "}
+        <span className="align-middle">{locationGroup.message}</span>
+      </h4>
+      {locationGroup.locations.map((location) => (
+        <div key={location.id} className="my-3">
+          <AirTableCard location={location} />
         </div>
-    ) : null;
+      ))}
+    </div>
+  ) : null;
 }
 
 const CountySpecificInfo = ({ info }) => {
-    return (
-        <div className="mt-2">
-            <div>
-                <a target="_blank" href={info.Website}>
-                    View Official County Website{" "}
-                    <FaExternalLinkAlt size=".85em" />
-                </a>
-            </div>
-            <div>
-                <a target="_blank" href={info["Vaccine Signup"]}>
-                    County Vaccine Preregistration{" "}
-                    <FaExternalLinkAlt size=".85em" />
-                </a>
-            </div>
-        </div>
-    );
+  return (
+    <div className="mt-2">
+      <div>
+        <a target="_blank" href={info.Website}>
+          View Official County Website <FaExternalLinkAlt size=".85em" />
+        </a>
+      </div>
+      <div>
+        <a target="_blank" href={info["Vaccine Signup"]}>
+          County Vaccine Preregistration <FaExternalLinkAlt size=".85em" />
+        </a>
+      </div>
+    </div>
+  );
 };
 
 function LatestReportsReceived({ latestReportedLocation }) {
-    if (latestReportedLocation) {
-        const latestReportTimeRaw =
-            latestReportedLocation.fields["Latest report"];
-        if (latestReportTimeRaw) {
-            return (
-                <span
-                    className="badge badge-primary font-weight-normal text-wrap"
-                    style={{ fontSize: "100%" }}
-                >
-                    Latest report for county received{" "}
-                    {moment(latestReportTimeRaw).fromNow()}
-                </span>
-            );
-        }
+  if (latestReportedLocation) {
+    const latestReportTimeRaw = latestReportedLocation.fields["Latest report"];
+    if (latestReportTimeRaw) {
+      return (
+        <span
+          className="badge badge-primary font-weight-normal text-wrap"
+          style={{ fontSize: "100%" }}
+        >
+          Latest report for county received{" "}
+          {moment(latestReportTimeRaw).fromNow()}
+        </span>
+      );
     }
+  }
 
-    return null;
+  return null;
 }
 
 export default function CountyPage({ county, countySpecificInfo, locations }) {
-    const latestReportedLocation =
-        locations.allLocations.length > 0 ? locations.allLocations[0] : null;
+  const latestReportedLocation =
+    locations.allLocations.length > 0 ? locations.allLocations[0] : null;
 
-    const recentLocationGroups = [
-        {
-            messageIcon: <FaCheckCircle />,
-            message: "Vaccines reported available",
-            messageColor: "text-success",
-            locations: locations.recentLocations.availableWalkIn,
-        },
-        {
-            messageIcon: <FaCheckCircle />,
-            message: "Vaccines reported available with appointment",
-            messageColor: "text-success",
-            locations: locations.recentLocations.availableAppointment,
-        },
-        {
-            messageIcon: <FaClipboardList />,
-            message: "Vaccine waitlist signup reported available",
-            messageColor: "text-info",
-            locations: locations.recentLocations.availableWaitlist,
-        },
-    ];
+  const recentLocationGroups = [
+    {
+      messageIcon: <FaCheckCircle />,
+      message: "Vaccines reported available",
+      messageColor: "text-success",
+      locations: locations.recentLocations.availableWalkIn,
+    },
+    {
+      messageIcon: <FaCheckCircle />,
+      message: "Vaccines reported available with appointment",
+      messageColor: "text-success",
+      locations: locations.recentLocations.availableAppointment,
+    },
+    {
+      messageIcon: <FaClipboardList />,
+      message: "Vaccine waitlist signup reported available",
+      messageColor: "text-info",
+      locations: locations.recentLocations.availableWaitlist,
+    },
+  ];
 
-    const outdatedLocationGroups = [
-        {
-            messageIcon: <FaCheckCircle />,
-            message: "Vaccines reported available",
-            messageColor: "text-success",
-            locations: locations.outdatedLocations.availableWalkIn,
-        },
-        {
-            messageIcon: <FaCheckCircle />,
-            message: "Vaccines reported available with appointment",
-            messageColor: "text-success",
-            locations: locations.outdatedLocations.availableAppointment,
-        },
-        {
-            messageIcon: <FaClipboardList />,
-            message: "Vaccine waitlist signup reported available",
-            messageColor: "text-info",
-            locations: locations.outdatedLocations.availableWaitlist,
-        },
-        {
-            messageIcon: <FaQuestionCircle />,
-            message: "Availability varies",
-            messageColor: "text-dark",
-            locations: locations.availabilityVaries,
-        },
-        {
-            messageIcon: <FaTimesCircle />,
-            message: "Vaccines reported unavailable",
-            messageColor: "text-danger",
-            locations: locations.noAvailability,
-        },
-        {
-            messageIcon: <FaQuestionCircle />,
-            message: "No confirmation / uncontacted",
-            messageColor: "text-dark",
-            locations: locations.noConfirmation,
-        },
-    ];
+  const outdatedLocationGroups = [
+    {
+      messageIcon: <FaCheckCircle />,
+      message: "Vaccines reported available",
+      messageColor: "text-success",
+      locations: locations.outdatedLocations.availableWalkIn,
+    },
+    {
+      messageIcon: <FaCheckCircle />,
+      message: "Vaccines reported available with appointment",
+      messageColor: "text-success",
+      locations: locations.outdatedLocations.availableAppointment,
+    },
+    {
+      messageIcon: <FaClipboardList />,
+      message: "Vaccine waitlist signup reported available",
+      messageColor: "text-info",
+      locations: locations.outdatedLocations.availableWaitlist,
+    },
+    {
+      messageIcon: <FaQuestionCircle />,
+      message: "Availability varies",
+      messageColor: "text-dark",
+      locations: locations.availabilityVaries,
+    },
+    {
+      messageIcon: <FaTimesCircle />,
+      message: "Vaccines reported unavailable",
+      messageColor: "text-danger",
+      locations: locations.noAvailability,
+    },
+    {
+      messageIcon: <FaQuestionCircle />,
+      message: "No confirmation / uncontacted",
+      messageColor: "text-dark",
+      locations: locations.noConfirmation,
+    },
+  ];
 
-    return (
-        <CountyPageLayout county={county}>
-            <div className="container-fluid container-xl mt-3">
-                <div className="ml-1 mb-2">
-                    <Link href="/">
-                        <a>
-                            <FaArrowLeft />{" "}
-                            <span className="align-middle">
-                                View all counties
-                            </span>
-                        </a>
-                    </Link>
-                </div>
-                <h1 className="mb-3">{county} COVID-19 Vaccine Availability</h1>
-                <div className="mb-5">
-                    <LatestReportsReceived
-                        latestReportedLocation={latestReportedLocation}
-                    />
-                    <CountySpecificInfo info={countySpecificInfo} />
-                </div>
+  return (
+    <CountyPageLayout county={county}>
+      <div className="container-fluid container-xl mt-3">
+        <div className="ml-1 mb-2">
+          <Link href="/">
+            <a>
+              <FaArrowLeft />{" "}
+              <span className="align-middle">View all counties</span>
+            </a>
+          </Link>
+        </div>
+        <h1 className="mb-3">{county} COVID-19 Vaccine Availability</h1>
+        <div className="mb-5">
+          <LatestReportsReceived
+            latestReportedLocation={latestReportedLocation}
+          />
+          <CountySpecificInfo info={countySpecificInfo} />
+        </div>
 
-                <p className="alert alert-light text-center mb-3 border">
-                    If you have a missing location to report, or think we have
-                    incorrect information,{" "}
-                    <a
-                        target="_blank"
-                        rel="noreferrer"
-                        href="https://airtable.com/shr7z01kc7h1ogP5R"
-                    >
-                        please let us know.
-                    </a>
-                </p>
-                <div className="d-flex flex-column">
-                    {locations.allLocations.length <= 0 ? (
-                        <>
-                            <h2 className="text-center mt-5">
-                                We currently have no locations for {county} on
-                                record.
-                            </h2>
-                            <h2 className="text-center">
-                                You can view all counties{" "}
-                                <Link href="/">here</Link>.
-                            </h2>
-                        </>
-                    ) : null}
-                    {recentLocationGroups.some(
-                        (locationGroup) => locationGroup.locations.length > 0
-                    ) ? (
-                        <>
-                            <h3 className="mb-0 font-weight-normal">
-                                <u>Recent availability:</u>
-                            </h3>
-                            {recentLocationGroups.map((locationGroup) => (
-                                <LocationGroup
-                                    key={locationGroup.message}
-                                    locationGroup={locationGroup}
-                                />
-                            ))}
-                        </>
-                    ) : null}
-                    {outdatedLocationGroups.some(
-                        (locationGroup) => locationGroup.locations.length > 0
-                    ) ? (
-                        <>
-                            <h3 className="mt-4 mb-0 font-weight-normal">
-                                <u>All reports:</u>
-                            </h3>
-                            {outdatedLocationGroups.map((locationGroup) => (
-                                <LocationGroup
-                                    key={locationGroup.message}
-                                    locationGroup={locationGroup}
-                                />
-                            ))}
-                        </>
-                    ) : null}
-                </div>
-            </div>
-        </CountyPageLayout>
-    );
+        <p className="alert alert-light text-center mb-3 border">
+          If you have a missing location to report, or think we have incorrect
+          information,{" "}
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href="https://airtable.com/shr7z01kc7h1ogP5R"
+          >
+            please let us know.
+          </a>
+        </p>
+        <div className="d-flex flex-column">
+          {locations.allLocations.length <= 0 ? (
+            <>
+              <h2 className="text-center mt-5">
+                We currently have no locations for {county} on record.
+              </h2>
+              <h2 className="text-center">
+                You can view all counties <Link href="/">here</Link>.
+              </h2>
+            </>
+          ) : null}
+          {recentLocationGroups.some(
+            (locationGroup) => locationGroup.locations.length > 0
+          ) ? (
+            <>
+              <h3 className="mb-0 font-weight-normal">
+                <u>Recent availability:</u>
+              </h3>
+              {recentLocationGroups.map((locationGroup) => (
+                <LocationGroup
+                  key={locationGroup.message}
+                  locationGroup={locationGroup}
+                />
+              ))}
+            </>
+          ) : null}
+          {outdatedLocationGroups.some(
+            (locationGroup) => locationGroup.locations.length > 0
+          ) ? (
+            <>
+              <h3 className="mt-4 mb-0 font-weight-normal">
+                <u>All reports:</u>
+              </h3>
+              {outdatedLocationGroups.map((locationGroup) => (
+                <LocationGroup
+                  key={locationGroup.message}
+                  locationGroup={locationGroup}
+                />
+              ))}
+            </>
+          ) : null}
+        </div>
+      </div>
+    </CountyPageLayout>
+  );
 }
 
 export async function getServerSideProps({ params }) {
-    const countyDecoded = titleCase(params.county.replace("_", " "));
-    if (!counties.includes(countyDecoded)) {
-        return {
-            notFound: true,
-        };
-    }
-
-    const countyLocations = await getCountyLocations(countyDecoded);
-    const countySpecificInfo = await getCountySpecificInfo(countyDecoded);
-
+  const countyDecoded = titleCase(params.county.replace("_", " "));
+  if (!counties.includes(countyDecoded)) {
     return {
-        props: {
-            county: countyDecoded,
-            countySpecificInfo: countySpecificInfo,
-            locations: countyLocations,
-        },
+      notFound: true,
     };
+  }
+
+  const countyLocations = await getCountyLocations(countyDecoded);
+  const countySpecificInfo = await getCountySpecificInfo(countyDecoded);
+
+  return {
+    props: {
+      county: countyDecoded,
+      countySpecificInfo: countySpecificInfo,
+      locations: countyLocations,
+    },
+  };
 }

--- a/pages/counties/[county].js
+++ b/pages/counties/[county].js
@@ -1,7 +1,7 @@
 import AirTableCard from "../../components/AirTableCard";
 import counties from "../../content/counties";
 import CountyPageLayout from "../../layouts/CountyPageLayout";
-import { getCountyLocations, getCountySpecificInfo } from "../../utils/Data";
+import { getCountyLocations, getCountyLinks } from "../../utils/Data";
 import {
   FaCheckCircle,
   FaTimesCircle,
@@ -35,20 +35,34 @@ function LocationGroup({ locationGroup }) {
   ) : null;
 }
 
-const CountySpecificInfo = ({ info }) => {
+const CountyLinks = ({ countyLinks }) => {
+  let countyCovidInfoLink = countyLinks['County COVID Information'] ? countyLinks['County COVID Information'].trim() : null;
+  if (countyCovidInfoLink && countyCovidInfoLink.length <= 0) {
+    countyCovidInfoLink = countyCovidInfoLink.trim();
+  }
+
+  let countyPreregistrationLink = countyLinks['County COVID Preregistration'] ? countyLinks['County COVID Preregistration'].trim() : null;
+  if (countyPreregistrationLink && countyPreregistrationLink.length <= 0) {
+    countyPreregistrationLink = null;
+  }
+
   return (
-    <div className="mt-2">
-      <div>
-        <a target="_blank" href={info.Website}>
-          View Official County Website <FaExternalLinkAlt size=".85em" />
-        </a>
-      </div>
-      <div>
-        <a target="_blank" href={info["Vaccine Signup"]}>
-          County Vaccine Preregistration <FaExternalLinkAlt size=".85em" />
-        </a>
-      </div>
-    </div>
+    <>
+      {countyCovidInfoLink ? (
+        <div>
+          <a target="_blank" href={countyCovidInfoLink}>
+            Official {countyLinks.County} COVID-19 <span className="text-nowrap">Information <FaExternalLinkAlt size=".85em" /></span>
+          </a>
+        </div>
+      ) : null}
+      {countyPreregistrationLink ? (
+        <div>
+          <a target="_blank" href={countyPreregistrationLink}>
+            Official {countyLinks.County} Vaccine <span className="text-nowrap">Preregistration <FaExternalLinkAlt size=".85em" /></span>
+          </a>
+        </div>
+      ) : null}
+    </>
   );
 };
 
@@ -71,7 +85,7 @@ function LatestReportsReceived({ latestReportedLocation }) {
   return null;
 }
 
-export default function CountyPage({ county, countySpecificInfo, locations }) {
+export default function CountyPage({ county, countyLinks, locations }) {
   const latestReportedLocation =
     locations.allLocations.length > 0 ? locations.allLocations[0] : null;
 
@@ -147,11 +161,15 @@ export default function CountyPage({ county, countySpecificInfo, locations }) {
           </Link>
         </div>
         <h1 className="mb-3">{county} COVID-19 Vaccine Availability</h1>
-        <div className="mb-5">
-          <LatestReportsReceived
-            latestReportedLocation={latestReportedLocation}
-          />
-          <CountySpecificInfo info={countySpecificInfo} />
+        <div className="mb-5 row">
+          <div className="col-md-6">
+            <LatestReportsReceived
+              latestReportedLocation={latestReportedLocation}
+            />
+          </div>
+          <div className="mt-2 col-md-6 text-md-right mt-md-0">
+            <CountyLinks countyLinks={countyLinks} />
+          </div>
         </div>
 
         <p className="alert alert-light text-center mb-3 border">
@@ -221,12 +239,12 @@ export async function getServerSideProps({ params }) {
   }
 
   const countyLocations = await getCountyLocations(countyDecoded);
-  const countySpecificInfo = await getCountySpecificInfo(countyDecoded);
+  const countyLinks = await getCountyLinks(countyDecoded);
 
   return {
     props: {
       county: countyDecoded,
-      countySpecificInfo: countySpecificInfo,
+      countyLinks: countyLinks,
       locations: countyLocations,
     },
   };

--- a/pages/counties/[county].js
+++ b/pages/counties/[county].js
@@ -1,212 +1,244 @@
 import AirTableCard from "../../components/AirTableCard";
 import counties from "../../content/counties";
 import CountyPageLayout from "../../layouts/CountyPageLayout";
-import { getCountyLocations } from "../../utils/Data";
+import { getCountyLocations, getCountySpecificInfo } from "../../utils/Data";
 import {
-  FaCheckCircle,
-  FaTimesCircle,
-  FaQuestionCircle,
-  FaArrowLeft,
-  FaClipboardList,
+    FaCheckCircle,
+    FaTimesCircle,
+    FaQuestionCircle,
+    FaArrowLeft,
+    FaClipboardList,
+    FaExternalLinkAlt,
 } from "react-icons/fa";
 import moment from "moment";
 import Link from "next/link";
 
 function titleCase(str) {
-  return str.replace(/(^|\s)\S/g, function (t) {
-    return t.toUpperCase();
-  });
+    return str.replace(/(^|\s)\S/g, function (t) {
+        return t.toUpperCase();
+    });
 }
 
 function LocationGroup({ locationGroup }) {
-  return locationGroup.locations.length > 0 ? (
-    <div>
-      <h4 className={locationGroup.messageColor + " font-weight-bold mt-3"}>
-        {locationGroup.messageIcon}{" "}
-        <span className="align-middle">{locationGroup.message}</span>
-      </h4>
-      {locationGroup.locations.map((location) => (
-        <div key={location.id} className="my-3">
-          <AirTableCard location={location} />
+    return locationGroup.locations.length > 0 ? (
+        <div>
+            <h4
+                className={
+                    locationGroup.messageColor + " font-weight-bold mt-3"
+                }
+            >
+                {locationGroup.messageIcon}{" "}
+                <span className="align-middle">{locationGroup.message}</span>
+            </h4>
+            {locationGroup.locations.map((location) => (
+                <div key={location.id} className="my-3">
+                    <AirTableCard location={location} />
+                </div>
+            ))}
         </div>
-      ))}
-    </div>
-  ) : null;
+    ) : null;
 }
+
+const CountySpecificInfo = ({ info }) => {
+    return (
+        <div className="mt-2">
+            <div>
+                <a target="_blank" href={info.Website}>
+                    View Official County Website{" "}
+                    <FaExternalLinkAlt size=".85em" />
+                </a>
+            </div>
+            <div>
+                <a target="_blank" href={info["Vaccine Signup"]}>
+                    County Vaccine Preregistration{" "}
+                    <FaExternalLinkAlt size=".85em" />
+                </a>
+            </div>
+        </div>
+    );
+};
 
 function LatestReportsReceived({ latestReportedLocation }) {
-  if (latestReportedLocation) {
-    const latestReportTimeRaw = latestReportedLocation.fields["Latest report"];
-    if (latestReportTimeRaw) {
-      return (
-        <span
-          className="badge badge-primary font-weight-normal text-wrap"
-          style={{ fontSize: "100%" }}
-        >
-          Latest report for county received{" "}
-          {moment(latestReportTimeRaw).fromNow()}
-        </span>
-      );
+    if (latestReportedLocation) {
+        const latestReportTimeRaw =
+            latestReportedLocation.fields["Latest report"];
+        if (latestReportTimeRaw) {
+            return (
+                <span
+                    className="badge badge-primary font-weight-normal text-wrap"
+                    style={{ fontSize: "100%" }}
+                >
+                    Latest report for county received{" "}
+                    {moment(latestReportTimeRaw).fromNow()}
+                </span>
+            );
+        }
     }
-  }
 
-  return null;
+    return null;
 }
 
-export default function CountyPage({ county, locations }) {
-  const latestReportedLocation =
-    locations.allLocations.length > 0 ? locations.allLocations[0] : null;
+export default function CountyPage({ county, countySpecificInfo, locations }) {
+    const latestReportedLocation =
+        locations.allLocations.length > 0 ? locations.allLocations[0] : null;
 
-  const recentLocationGroups = [
-    {
-      messageIcon: <FaCheckCircle />,
-      message: "Vaccines reported available",
-      messageColor: "text-success",
-      locations: locations.recentLocations.availableWalkIn,
-    },
-    {
-      messageIcon: <FaCheckCircle />,
-      message: "Vaccines reported available with appointment",
-      messageColor: "text-success",
-      locations: locations.recentLocations.availableAppointment,
-    },
-    {
-      messageIcon: <FaClipboardList />,
-      message: "Vaccine waitlist signup reported available",
-      messageColor: "text-info",
-      locations: locations.recentLocations.availableWaitlist,
-    },
-  ];
+    const recentLocationGroups = [
+        {
+            messageIcon: <FaCheckCircle />,
+            message: "Vaccines reported available",
+            messageColor: "text-success",
+            locations: locations.recentLocations.availableWalkIn,
+        },
+        {
+            messageIcon: <FaCheckCircle />,
+            message: "Vaccines reported available with appointment",
+            messageColor: "text-success",
+            locations: locations.recentLocations.availableAppointment,
+        },
+        {
+            messageIcon: <FaClipboardList />,
+            message: "Vaccine waitlist signup reported available",
+            messageColor: "text-info",
+            locations: locations.recentLocations.availableWaitlist,
+        },
+    ];
 
-  const outdatedLocationGroups = [
-    {
-      messageIcon: <FaCheckCircle />,
-      message: "Vaccines reported available",
-      messageColor: "text-success",
-      locations: locations.outdatedLocations.availableWalkIn,
-    },
-    {
-      messageIcon: <FaCheckCircle />,
-      message: "Vaccines reported available with appointment",
-      messageColor: "text-success",
-      locations: locations.outdatedLocations.availableAppointment,
-    },
-    {
-      messageIcon: <FaClipboardList />,
-      message: "Vaccine waitlist signup reported available",
-      messageColor: "text-info",
-      locations: locations.outdatedLocations.availableWaitlist,
-    },
-    {
-      messageIcon: <FaQuestionCircle />,
-      message: "Availability varies",
-      messageColor: "text-dark",
-      locations: locations.availabilityVaries,
-    },
-    {
-      messageIcon: <FaTimesCircle />,
-      message: "Vaccines reported unavailable",
-      messageColor: "text-danger",
-      locations: locations.noAvailability,
-    },
-    {
-      messageIcon: <FaQuestionCircle />,
-      message: "No confirmation / uncontacted",
-      messageColor: "text-dark",
-      locations: locations.noConfirmation,
-    },
-  ];
+    const outdatedLocationGroups = [
+        {
+            messageIcon: <FaCheckCircle />,
+            message: "Vaccines reported available",
+            messageColor: "text-success",
+            locations: locations.outdatedLocations.availableWalkIn,
+        },
+        {
+            messageIcon: <FaCheckCircle />,
+            message: "Vaccines reported available with appointment",
+            messageColor: "text-success",
+            locations: locations.outdatedLocations.availableAppointment,
+        },
+        {
+            messageIcon: <FaClipboardList />,
+            message: "Vaccine waitlist signup reported available",
+            messageColor: "text-info",
+            locations: locations.outdatedLocations.availableWaitlist,
+        },
+        {
+            messageIcon: <FaQuestionCircle />,
+            message: "Availability varies",
+            messageColor: "text-dark",
+            locations: locations.availabilityVaries,
+        },
+        {
+            messageIcon: <FaTimesCircle />,
+            message: "Vaccines reported unavailable",
+            messageColor: "text-danger",
+            locations: locations.noAvailability,
+        },
+        {
+            messageIcon: <FaQuestionCircle />,
+            message: "No confirmation / uncontacted",
+            messageColor: "text-dark",
+            locations: locations.noConfirmation,
+        },
+    ];
 
-  return (
-    <CountyPageLayout county={county}>
-      <div className="container-fluid container-xl mt-3">
-        <div className="ml-1 mb-2">
-          <Link href="/">
-            <a>
-              <FaArrowLeft />{" "}
-              <span className="align-middle">View all counties</span>
-            </a>
-          </Link>
-        </div>
-        <h1 className="mb-3">{county} COVID-19 Vaccine Availability</h1>
-        <div className="mb-5">
-          <LatestReportsReceived
-            latestReportedLocation={latestReportedLocation}
-          />
-        </div>
+    return (
+        <CountyPageLayout county={county}>
+            <div className="container-fluid container-xl mt-3">
+                <div className="ml-1 mb-2">
+                    <Link href="/">
+                        <a>
+                            <FaArrowLeft />{" "}
+                            <span className="align-middle">
+                                View all counties
+                            </span>
+                        </a>
+                    </Link>
+                </div>
+                <h1 className="mb-3">{county} COVID-19 Vaccine Availability</h1>
+                <div className="mb-5">
+                    <LatestReportsReceived
+                        latestReportedLocation={latestReportedLocation}
+                    />
+                    <CountySpecificInfo info={countySpecificInfo} />
+                </div>
 
-        <p className="alert alert-light text-center mb-3 border">
-          If you have a missing location to report, or think we have incorrect
-          information,{" "}
-          <a
-            target="_blank"
-            rel="noreferrer"
-            href="https://airtable.com/shr7z01kc7h1ogP5R"
-          >
-            please let us know.
-          </a>
-        </p>
-        <div className="d-flex flex-column">
-          {locations.allLocations.length <= 0 ? (
-            <>
-              <h2 className="text-center mt-5">
-                We currently have no locations for {county} on record.
-              </h2>
-              <h2 className="text-center">
-                You can view all counties <Link href="/">here</Link>.
-              </h2>
-            </>
-          ) : null}
-          {recentLocationGroups.some(
-            (locationGroup) => locationGroup.locations.length > 0
-          ) ? (
-            <>
-              <h3 className="mb-0 font-weight-normal">
-                <u>Recent availability:</u>
-              </h3>
-              {recentLocationGroups.map((locationGroup) => (
-                <LocationGroup
-                  key={locationGroup.message}
-                  locationGroup={locationGroup}
-                />
-              ))}
-            </>
-          ) : null}
-          {outdatedLocationGroups.some(
-            (locationGroup) => locationGroup.locations.length > 0
-          ) ? (
-            <>
-              <h3 className="mt-4 mb-0 font-weight-normal">
-                <u>All reports:</u>
-              </h3>
-              {outdatedLocationGroups.map((locationGroup) => (
-                <LocationGroup
-                  key={locationGroup.message}
-                  locationGroup={locationGroup}
-                />
-              ))}
-            </>
-          ) : null}
-        </div>
-      </div>
-    </CountyPageLayout>
-  );
+                <p className="alert alert-light text-center mb-3 border">
+                    If you have a missing location to report, or think we have
+                    incorrect information,{" "}
+                    <a
+                        target="_blank"
+                        rel="noreferrer"
+                        href="https://airtable.com/shr7z01kc7h1ogP5R"
+                    >
+                        please let us know.
+                    </a>
+                </p>
+                <div className="d-flex flex-column">
+                    {locations.allLocations.length <= 0 ? (
+                        <>
+                            <h2 className="text-center mt-5">
+                                We currently have no locations for {county} on
+                                record.
+                            </h2>
+                            <h2 className="text-center">
+                                You can view all counties{" "}
+                                <Link href="/">here</Link>.
+                            </h2>
+                        </>
+                    ) : null}
+                    {recentLocationGroups.some(
+                        (locationGroup) => locationGroup.locations.length > 0
+                    ) ? (
+                        <>
+                            <h3 className="mb-0 font-weight-normal">
+                                <u>Recent availability:</u>
+                            </h3>
+                            {recentLocationGroups.map((locationGroup) => (
+                                <LocationGroup
+                                    key={locationGroup.message}
+                                    locationGroup={locationGroup}
+                                />
+                            ))}
+                        </>
+                    ) : null}
+                    {outdatedLocationGroups.some(
+                        (locationGroup) => locationGroup.locations.length > 0
+                    ) ? (
+                        <>
+                            <h3 className="mt-4 mb-0 font-weight-normal">
+                                <u>All reports:</u>
+                            </h3>
+                            {outdatedLocationGroups.map((locationGroup) => (
+                                <LocationGroup
+                                    key={locationGroup.message}
+                                    locationGroup={locationGroup}
+                                />
+                            ))}
+                        </>
+                    ) : null}
+                </div>
+            </div>
+        </CountyPageLayout>
+    );
 }
 
 export async function getServerSideProps({ params }) {
-  const countyDecoded = titleCase(params.county.replace("_", " "));
-  if (!counties.includes(countyDecoded)) {
+    const countyDecoded = titleCase(params.county.replace("_", " "));
+    if (!counties.includes(countyDecoded)) {
+        return {
+            notFound: true,
+        };
+    }
+
+    const countyLocations = await getCountyLocations(countyDecoded);
+    const countySpecificInfo = await getCountySpecificInfo(countyDecoded);
+
     return {
-      notFound: true,
+        props: {
+            county: countyDecoded,
+            countySpecificInfo: countySpecificInfo,
+            locations: countyLocations,
+        },
     };
-  }
-
-  const countyLocations = await getCountyLocations(countyDecoded);
-
-  return {
-    props: {
-      county: countyDecoded,
-      locations: countyLocations,
-    },
-  };
 }

--- a/utils/Data.js
+++ b/utils/Data.js
@@ -87,7 +87,7 @@ export function getAvailabilityStatus(vaccinesAvailableString) {
   return AVAILABILITY_STATUS.UNKNOWN;
 }
 
-export async function getCountySpecificInfo(county) {
+export async function getCountyLinks(county) {
   const countyLinks = await fetchAirtableData(
     "county-links",
     Airtable.base("appdsheneg5ii1EnQ")("Counties").select()

--- a/utils/Data.js
+++ b/utils/Data.js
@@ -4,175 +4,196 @@ import NodeCache from "node-cache";
 const OUTDATED_DAYS_THRESHOLD = 3;
 
 const airtableBackupCache = new NodeCache({
-  deleteOnExpire: false,
-  stdTTL: 0,
+    deleteOnExpire: false,
+    stdTTL: 0,
 });
 const airtableCache = new NodeCache({
-  stdTTL: 600, // Ten minutes
+    stdTTL: 600, // Ten minutes
 });
 
 Airtable.configure({ apiKey: process.env.AIRTABLE_KEY });
 
 export const AVAILABILITY_STATUS = {
-  UNKNOWN: {
-    value: 0,
-    string: "No confirmation / unknown",
-    isAvailable: false,
-  },
-  NO: { value: 1, string: "No", isAvailable: false },
-  VARIES: { value: 2, string: "Availability varies", isAvailable: false },
-  APPOINTMENT: {
-    value: 3,
-    string: "Yes, with appointment only",
-    display: "With Appointment Only",
-    isAvailable: true,
-  },
-  WALK_IN: {
-    value: 4,
-    string: "Yes, walk-ins accepted",
-    display: "Walk-ins Accepted",
-    isAvailable: true,
-  },
-  WAITLIST: {
-    value: 5,
-    string: "Waitlist Only",
-    display: "Waitlist Only",
-    isAvailable: true,
-  },
+    UNKNOWN: {
+        value: 0,
+        string: "No confirmation / unknown",
+        isAvailable: false,
+    },
+    NO: { value: 1, string: "No", isAvailable: false },
+    VARIES: { value: 2, string: "Availability varies", isAvailable: false },
+    APPOINTMENT: {
+        value: 3,
+        string: "Yes, with appointment only",
+        display: "With Appointment Only",
+        isAvailable: true,
+    },
+    WALK_IN: {
+        value: 4,
+        string: "Yes, walk-ins accepted",
+        display: "Walk-ins Accepted",
+        isAvailable: true,
+    },
+    WAITLIST: {
+        value: 5,
+        string: "Waitlist Only",
+        display: "Waitlist Only",
+        isAvailable: true,
+    },
 };
 
 export async function fetchAirtableData(cacheKeyword, airtableQuery) {
-  let data = airtableCache.get(cacheKeyword);
-  if (data == undefined) {
-    try {
-      data = await airtableQuery.all();
+    let data = airtableCache.get(cacheKeyword);
+    if (data == undefined) {
+        try {
+            data = await airtableQuery.all();
 
-      airtableCache.set(cacheKeyword, data);
-      airtableBackupCache.set(cacheKeyword, data);
-    } catch (error) {
-      console.error(error);
+            airtableCache.set(cacheKeyword, data);
+            airtableBackupCache.set(cacheKeyword, data);
+        } catch (error) {
+            console.error(error);
 
-      // Attempt to load from backup cache.
-      data = airtableBackupCache.get(cacheKeyword);
+            // Attempt to load from backup cache.
+            data = airtableBackupCache.get(cacheKeyword);
 
-      if (data == undefined) {
-        throw error;
-      } else {
-        // Reset the main cache to backup.
-        console.log("Setting cache to backup.");
-        airtableCache.set(cacheKeyword, data);
-      }
+            if (data == undefined) {
+                throw error;
+            } else {
+                // Reset the main cache to backup.
+                console.log("Setting cache to backup.");
+                airtableCache.set(cacheKeyword, data);
+            }
+        }
     }
-  }
 
-  return data;
+    return data;
 }
 
 // TODO: Not ideal, should look to change this in the AirTable soon.
 export function getAvailabilityStatus(vaccinesAvailableString) {
-  if (vaccinesAvailableString) {
-    for (let statusValue in AVAILABILITY_STATUS) {
-      if (
-        vaccinesAvailableString[0] === AVAILABILITY_STATUS[statusValue].string
-      ) {
-        return AVAILABILITY_STATUS[statusValue];
-      }
+    if (vaccinesAvailableString) {
+        for (let statusValue in AVAILABILITY_STATUS) {
+            if (
+                vaccinesAvailableString[0] ===
+                AVAILABILITY_STATUS[statusValue].string
+            ) {
+                return AVAILABILITY_STATUS[statusValue];
+            }
+        }
+
+        console.log(
+            `Encountered unknown availability status: '${vaccinesAvailableString}'`
+        );
     }
 
-    console.log(
-      `Encountered unknown availability status: '${vaccinesAvailableString}'`
-    );
-  }
+    return AVAILABILITY_STATUS.UNKNOWN;
+}
 
-  return AVAILABILITY_STATUS.UNKNOWN;
+export async function getCountySpecificInfo(county) {
+    const countyLinks = await fetchAirtableData(
+        "county-links",
+        Airtable.base("appdsheneg5ii1EnQ")("Counties").select()
+    );
+
+    const countySpecificInfo = countyLinks
+        .map((record) => record._rawJson)
+        .filter((record) => record.fields.County === county);
+
+    if (countySpecificInfo.length > 0) {
+        return countySpecificInfo[0].fields;
+    } else {
+        return {};
+    }
 }
 
 export async function getCountyLocations(county) {
-  const countyLocations = (
-    await fetchAirtableData(
-      county,
-      Airtable.base("appdsheneg5ii1EnQ")("Locations").select({
-        filterByFormula: `County = "${county}"`,
-        sort: [
-          {
-            field: "Latest report",
-            direction: "desc",
-          },
-        ],
-      })
-    )
-  ).map((record) => record._rawJson);
+    const countyLocations = (
+        await fetchAirtableData(
+            county,
+            Airtable.base("appdsheneg5ii1EnQ")("Locations").select({
+                filterByFormula: `County = "${county}"`,
+                sort: [
+                    {
+                        field: "Latest report",
+                        direction: "desc",
+                    },
+                ],
+            })
+        )
+    ).map((record) => record._rawJson);
 
-  for (let i = 0; i < countyLocations.length; i++) {
-    countyLocations[i].availabilityStatus = getAvailabilityStatus(
-      countyLocations[i].fields["Vaccines available?"]
+    for (let i = 0; i < countyLocations.length; i++) {
+        countyLocations[i].availabilityStatus = getAvailabilityStatus(
+            countyLocations[i].fields["Vaccines available?"]
+        );
+    }
+
+    const outdatedThreshold = new Date();
+    outdatedThreshold.setDate(
+        outdatedThreshold.getDate() - OUTDATED_DAYS_THRESHOLD
     );
-  }
 
-  const outdatedThreshold = new Date();
-  outdatedThreshold.setDate(
-    outdatedThreshold.getDate() - OUTDATED_DAYS_THRESHOLD
-  );
-
-  const allRecentLocations = countyLocations.filter(
-    (location) =>
-      location.fields["Latest report"] &&
-      Date.parse(location.fields["Latest report"]) > outdatedThreshold
-  );
-  const allOutdatedLocations = countyLocations.filter(
-    (location) =>
-      location.fields["Latest report"] &&
-      Date.parse(location.fields["Latest report"]) <= outdatedThreshold
-  );
-  return {
-    allLocations: countyLocations,
-    allRecentLocations: allRecentLocations,
-    allOutdatedLocations: allOutdatedLocations,
-    recentLocations: {
-      availableWaitlist: allRecentLocations.filter(
+    const allRecentLocations = countyLocations.filter(
         (location) =>
-          location.availabilityStatus.value ===
-          AVAILABILITY_STATUS.WAITLIST.value
-      ),
-      availableAppointment: allRecentLocations.filter(
+            location.fields["Latest report"] &&
+            Date.parse(location.fields["Latest report"]) > outdatedThreshold
+    );
+    const allOutdatedLocations = countyLocations.filter(
         (location) =>
-          location.availabilityStatus.value ===
-          AVAILABILITY_STATUS.APPOINTMENT.value
-      ),
-      availableWalkIn: allRecentLocations.filter(
-        (location) =>
-          location.availabilityStatus.value ===
-          AVAILABILITY_STATUS.WALK_IN.value
-      ),
-    },
-    outdatedLocations: {
-      availableWaitlist: allOutdatedLocations.filter(
-        (location) =>
-          location.availabilityStatus.value ===
-          AVAILABILITY_STATUS.WAITLIST.value
-      ),
-      availableAppointment: allOutdatedLocations.filter(
-        (location) =>
-          location.availabilityStatus.value ===
-          AVAILABILITY_STATUS.APPOINTMENT.value
-      ),
-      availableWalkIn: allOutdatedLocations.filter(
-        (location) =>
-          location.availabilityStatus.value ===
-          AVAILABILITY_STATUS.WALK_IN.value
-      ),
-    },
-    availabilityVaries: countyLocations.filter(
-      (location) =>
-        location.availabilityStatus.value === AVAILABILITY_STATUS.VARIES.value
-    ),
-    noAvailability: countyLocations.filter(
-      (location) =>
-        location.availabilityStatus.value === AVAILABILITY_STATUS.NO.value
-    ),
-    noConfirmation: countyLocations.filter(
-      (location) =>
-        location.availabilityStatus.value === AVAILABILITY_STATUS.UNKNOWN.value
-    ),
-  };
+            location.fields["Latest report"] &&
+            Date.parse(location.fields["Latest report"]) <= outdatedThreshold
+    );
+    return {
+        allLocations: countyLocations,
+        allRecentLocations: allRecentLocations,
+        allOutdatedLocations: allOutdatedLocations,
+        recentLocations: {
+            availableWaitlist: allRecentLocations.filter(
+                (location) =>
+                    location.availabilityStatus.value ===
+                    AVAILABILITY_STATUS.WAITLIST.value
+            ),
+            availableAppointment: allRecentLocations.filter(
+                (location) =>
+                    location.availabilityStatus.value ===
+                    AVAILABILITY_STATUS.APPOINTMENT.value
+            ),
+            availableWalkIn: allRecentLocations.filter(
+                (location) =>
+                    location.availabilityStatus.value ===
+                    AVAILABILITY_STATUS.WALK_IN.value
+            ),
+        },
+        outdatedLocations: {
+            availableWaitlist: allOutdatedLocations.filter(
+                (location) =>
+                    location.availabilityStatus.value ===
+                    AVAILABILITY_STATUS.WAITLIST.value
+            ),
+            availableAppointment: allOutdatedLocations.filter(
+                (location) =>
+                    location.availabilityStatus.value ===
+                    AVAILABILITY_STATUS.APPOINTMENT.value
+            ),
+            availableWalkIn: allOutdatedLocations.filter(
+                (location) =>
+                    location.availabilityStatus.value ===
+                    AVAILABILITY_STATUS.WALK_IN.value
+            ),
+        },
+        availabilityVaries: countyLocations.filter(
+            (location) =>
+                location.availabilityStatus.value ===
+                AVAILABILITY_STATUS.VARIES.value
+        ),
+        noAvailability: countyLocations.filter(
+            (location) =>
+                location.availabilityStatus.value ===
+                AVAILABILITY_STATUS.NO.value
+        ),
+        noConfirmation: countyLocations.filter(
+            (location) =>
+                location.availabilityStatus.value ===
+                AVAILABILITY_STATUS.UNKNOWN.value
+        ),
+    };
 }

--- a/utils/Data.js
+++ b/utils/Data.js
@@ -4,196 +4,192 @@ import NodeCache from "node-cache";
 const OUTDATED_DAYS_THRESHOLD = 3;
 
 const airtableBackupCache = new NodeCache({
-    deleteOnExpire: false,
-    stdTTL: 0,
+  deleteOnExpire: false,
+  stdTTL: 0,
 });
 const airtableCache = new NodeCache({
-    stdTTL: 600, // Ten minutes
+  stdTTL: 600, // Ten minutes
 });
 
 Airtable.configure({ apiKey: process.env.AIRTABLE_KEY });
 
 export const AVAILABILITY_STATUS = {
-    UNKNOWN: {
-        value: 0,
-        string: "No confirmation / unknown",
-        isAvailable: false,
-    },
-    NO: { value: 1, string: "No", isAvailable: false },
-    VARIES: { value: 2, string: "Availability varies", isAvailable: false },
-    APPOINTMENT: {
-        value: 3,
-        string: "Yes, with appointment only",
-        display: "With Appointment Only",
-        isAvailable: true,
-    },
-    WALK_IN: {
-        value: 4,
-        string: "Yes, walk-ins accepted",
-        display: "Walk-ins Accepted",
-        isAvailable: true,
-    },
-    WAITLIST: {
-        value: 5,
-        string: "Waitlist Only",
-        display: "Waitlist Only",
-        isAvailable: true,
-    },
+  UNKNOWN: {
+    value: 0,
+    string: "No confirmation / unknown",
+    isAvailable: false,
+  },
+  NO: { value: 1, string: "No", isAvailable: false },
+  VARIES: { value: 2, string: "Availability varies", isAvailable: false },
+  APPOINTMENT: {
+    value: 3,
+    string: "Yes, with appointment only",
+    display: "With Appointment Only",
+    isAvailable: true,
+  },
+  WALK_IN: {
+    value: 4,
+    string: "Yes, walk-ins accepted",
+    display: "Walk-ins Accepted",
+    isAvailable: true,
+  },
+  WAITLIST: {
+    value: 5,
+    string: "Waitlist Only",
+    display: "Waitlist Only",
+    isAvailable: true,
+  },
 };
 
 export async function fetchAirtableData(cacheKeyword, airtableQuery) {
-    let data = airtableCache.get(cacheKeyword);
-    if (data == undefined) {
-        try {
-            data = await airtableQuery.all();
+  let data = airtableCache.get(cacheKeyword);
+  if (data == undefined) {
+    try {
+      data = await airtableQuery.all();
 
-            airtableCache.set(cacheKeyword, data);
-            airtableBackupCache.set(cacheKeyword, data);
-        } catch (error) {
-            console.error(error);
+      airtableCache.set(cacheKeyword, data);
+      airtableBackupCache.set(cacheKeyword, data);
+    } catch (error) {
+      console.error(error);
 
-            // Attempt to load from backup cache.
-            data = airtableBackupCache.get(cacheKeyword);
+      // Attempt to load from backup cache.
+      data = airtableBackupCache.get(cacheKeyword);
 
-            if (data == undefined) {
-                throw error;
-            } else {
-                // Reset the main cache to backup.
-                console.log("Setting cache to backup.");
-                airtableCache.set(cacheKeyword, data);
-            }
-        }
+      if (data == undefined) {
+        throw error;
+      } else {
+        // Reset the main cache to backup.
+        console.log("Setting cache to backup.");
+        airtableCache.set(cacheKeyword, data);
+      }
     }
+  }
 
-    return data;
+  return data;
 }
 
 // TODO: Not ideal, should look to change this in the AirTable soon.
 export function getAvailabilityStatus(vaccinesAvailableString) {
-    if (vaccinesAvailableString) {
-        for (let statusValue in AVAILABILITY_STATUS) {
-            if (
-                vaccinesAvailableString[0] ===
-                AVAILABILITY_STATUS[statusValue].string
-            ) {
-                return AVAILABILITY_STATUS[statusValue];
-            }
-        }
-
-        console.log(
-            `Encountered unknown availability status: '${vaccinesAvailableString}'`
-        );
+  if (vaccinesAvailableString) {
+    for (let statusValue in AVAILABILITY_STATUS) {
+      if (
+        vaccinesAvailableString[0] === AVAILABILITY_STATUS[statusValue].string
+      ) {
+        return AVAILABILITY_STATUS[statusValue];
+      }
     }
 
-    return AVAILABILITY_STATUS.UNKNOWN;
+    console.log(
+      `Encountered unknown availability status: '${vaccinesAvailableString}'`
+    );
+  }
+
+  return AVAILABILITY_STATUS.UNKNOWN;
 }
 
 export async function getCountySpecificInfo(county) {
-    const countyLinks = await fetchAirtableData(
-        "county-links",
-        Airtable.base("appdsheneg5ii1EnQ")("Counties").select()
-    );
+  const countyLinks = await fetchAirtableData(
+    "county-links",
+    Airtable.base("appdsheneg5ii1EnQ")("Counties").select()
+  );
 
-    const countySpecificInfo = countyLinks
-        .map((record) => record._rawJson)
-        .filter((record) => record.fields.County === county);
+  const countySpecificInfo = countyLinks
+    .map((record) => record._rawJson)
+    .filter((record) => record.fields.County === county);
 
-    if (countySpecificInfo.length > 0) {
-        return countySpecificInfo[0].fields;
-    } else {
-        return {};
-    }
+  if (countySpecificInfo.length > 0) {
+    return countySpecificInfo[0].fields;
+  } else {
+    return {};
+  }
 }
 
 export async function getCountyLocations(county) {
-    const countyLocations = (
-        await fetchAirtableData(
-            county,
-            Airtable.base("appdsheneg5ii1EnQ")("Locations").select({
-                filterByFormula: `County = "${county}"`,
-                sort: [
-                    {
-                        field: "Latest report",
-                        direction: "desc",
-                    },
-                ],
-            })
-        )
-    ).map((record) => record._rawJson);
+  const countyLocations = (
+    await fetchAirtableData(
+      county,
+      Airtable.base("appdsheneg5ii1EnQ")("Locations").select({
+        filterByFormula: `County = "${county}"`,
+        sort: [
+          {
+            field: "Latest report",
+            direction: "desc",
+          },
+        ],
+      })
+    )
+  ).map((record) => record._rawJson);
 
-    for (let i = 0; i < countyLocations.length; i++) {
-        countyLocations[i].availabilityStatus = getAvailabilityStatus(
-            countyLocations[i].fields["Vaccines available?"]
-        );
-    }
-
-    const outdatedThreshold = new Date();
-    outdatedThreshold.setDate(
-        outdatedThreshold.getDate() - OUTDATED_DAYS_THRESHOLD
+  for (let i = 0; i < countyLocations.length; i++) {
+    countyLocations[i].availabilityStatus = getAvailabilityStatus(
+      countyLocations[i].fields["Vaccines available?"]
     );
+  }
 
-    const allRecentLocations = countyLocations.filter(
+  const outdatedThreshold = new Date();
+  outdatedThreshold.setDate(
+    outdatedThreshold.getDate() - OUTDATED_DAYS_THRESHOLD
+  );
+
+  const allRecentLocations = countyLocations.filter(
+    (location) =>
+      location.fields["Latest report"] &&
+      Date.parse(location.fields["Latest report"]) > outdatedThreshold
+  );
+  const allOutdatedLocations = countyLocations.filter(
+    (location) =>
+      location.fields["Latest report"] &&
+      Date.parse(location.fields["Latest report"]) <= outdatedThreshold
+  );
+  return {
+    allLocations: countyLocations,
+    allRecentLocations: allRecentLocations,
+    allOutdatedLocations: allOutdatedLocations,
+    recentLocations: {
+      availableWaitlist: allRecentLocations.filter(
         (location) =>
-            location.fields["Latest report"] &&
-            Date.parse(location.fields["Latest report"]) > outdatedThreshold
-    );
-    const allOutdatedLocations = countyLocations.filter(
+          location.availabilityStatus.value ===
+          AVAILABILITY_STATUS.WAITLIST.value
+      ),
+      availableAppointment: allRecentLocations.filter(
         (location) =>
-            location.fields["Latest report"] &&
-            Date.parse(location.fields["Latest report"]) <= outdatedThreshold
-    );
-    return {
-        allLocations: countyLocations,
-        allRecentLocations: allRecentLocations,
-        allOutdatedLocations: allOutdatedLocations,
-        recentLocations: {
-            availableWaitlist: allRecentLocations.filter(
-                (location) =>
-                    location.availabilityStatus.value ===
-                    AVAILABILITY_STATUS.WAITLIST.value
-            ),
-            availableAppointment: allRecentLocations.filter(
-                (location) =>
-                    location.availabilityStatus.value ===
-                    AVAILABILITY_STATUS.APPOINTMENT.value
-            ),
-            availableWalkIn: allRecentLocations.filter(
-                (location) =>
-                    location.availabilityStatus.value ===
-                    AVAILABILITY_STATUS.WALK_IN.value
-            ),
-        },
-        outdatedLocations: {
-            availableWaitlist: allOutdatedLocations.filter(
-                (location) =>
-                    location.availabilityStatus.value ===
-                    AVAILABILITY_STATUS.WAITLIST.value
-            ),
-            availableAppointment: allOutdatedLocations.filter(
-                (location) =>
-                    location.availabilityStatus.value ===
-                    AVAILABILITY_STATUS.APPOINTMENT.value
-            ),
-            availableWalkIn: allOutdatedLocations.filter(
-                (location) =>
-                    location.availabilityStatus.value ===
-                    AVAILABILITY_STATUS.WALK_IN.value
-            ),
-        },
-        availabilityVaries: countyLocations.filter(
-            (location) =>
-                location.availabilityStatus.value ===
-                AVAILABILITY_STATUS.VARIES.value
-        ),
-        noAvailability: countyLocations.filter(
-            (location) =>
-                location.availabilityStatus.value ===
-                AVAILABILITY_STATUS.NO.value
-        ),
-        noConfirmation: countyLocations.filter(
-            (location) =>
-                location.availabilityStatus.value ===
-                AVAILABILITY_STATUS.UNKNOWN.value
-        ),
-    };
+          location.availabilityStatus.value ===
+          AVAILABILITY_STATUS.APPOINTMENT.value
+      ),
+      availableWalkIn: allRecentLocations.filter(
+        (location) =>
+          location.availabilityStatus.value ===
+          AVAILABILITY_STATUS.WALK_IN.value
+      ),
+    },
+    outdatedLocations: {
+      availableWaitlist: allOutdatedLocations.filter(
+        (location) =>
+          location.availabilityStatus.value ===
+          AVAILABILITY_STATUS.WAITLIST.value
+      ),
+      availableAppointment: allOutdatedLocations.filter(
+        (location) =>
+          location.availabilityStatus.value ===
+          AVAILABILITY_STATUS.APPOINTMENT.value
+      ),
+      availableWalkIn: allOutdatedLocations.filter(
+        (location) =>
+          location.availabilityStatus.value ===
+          AVAILABILITY_STATUS.WALK_IN.value
+      ),
+    },
+    availabilityVaries: countyLocations.filter(
+      (location) =>
+        location.availabilityStatus.value === AVAILABILITY_STATUS.VARIES.value
+    ),
+    noAvailability: countyLocations.filter(
+      (location) =>
+        location.availabilityStatus.value === AVAILABILITY_STATUS.NO.value
+    ),
+    noConfirmation: countyLocations.filter(
+      (location) =>
+        location.availabilityStatus.value === AVAILABILITY_STATUS.UNKNOWN.value
+    ),
+  };
 }


### PR DESCRIPTION

1. Took this spreadsheet and put it in Airtable under a "counties" table: https://docs.google.com/spreadsheets/d/1VVtxya-i9Tka6-uhrLvXPan9qqpt8og2Wz-pT8yawng/edit#gid=0
2. Added a function that fetches the county information, caches, and then a filter is done for the specific county. Dont think this incurs a performance penalty, since it will likely be cached whenever people reach it

![image](https://user-images.githubusercontent.com/13937711/108637168-7c38b500-7457-11eb-98ff-076c79c802ed.png)
