### PR TITLE
removed dead link for Lebanon Cty prereg

### DIFF
--- a/content/additional-resources.md
+++ b/content/additional-resources.md
@@ -24,5 +24,4 @@ People working or living in specific counties may be able to complete a pre-regi
 - Bucks County [pre-registration](https://buckscovid.powerappsportals.us/Vaccine-Registration/)
 - Chester County [pre-registration](https://chesco.seamlessdocs.com/f/chescovac)
 - Delaware County [pre-registration](https://chesco.seamlessdocs.com/f/delcovac)
-- Lebanon County [pre-registration](https://www.lcdes.org/vaccinate/)
 - Montgomery County [pre-registration](https://www.montcopa.org/3660/COVID-19-Vaccine)


### PR DESCRIPTION
they don't have prereg anymore -- only link I found for them off their covid info site was this https://docs.google.com/forms/d/e/1FAIpQLSfYyHv1Wn3Tko7cvn6sEUq6G0_jVzebHmIdeeibRxugVNHvKQ/viewform
which is just for first responders and essential workers