### PR TITLE
Add google translate functionality

### DIFF
--- a/components/AirTableCard.js
+++ b/components/AirTableCard.js
@@ -36,8 +36,11 @@ function formatWebsite(website) {
 
   // Ensure the website has a protocol defined (otherwise redirects to local page)
   // https://stackoverflow.com/questions/3543187/prepending-http-to-a-url-that-doesnt-already-contain-http
-  if (websiteFormatted.indexOf('://') === -1 && websiteFormatted.indexOf('mailto:') === -1) {
-    websiteFormatted = 'http://' + websiteFormatted;
+  if (
+    websiteFormatted.indexOf("://") === -1 &&
+    websiteFormatted.indexOf("mailto:") === -1
+  ) {
+    websiteFormatted = "http://" + websiteFormatted;
   }
 
   return websiteFormatted;

--- a/components/AirTableCard.js
+++ b/components/AirTableCard.js
@@ -31,6 +31,18 @@ const linkDecorator = (href, text, key) => (
 //   }
 // };
 
+function formatWebsite(website) {
+  let websiteFormatted = website.trim();
+
+  // Ensure the website has a protocol defined (otherwise redirects to local page)
+  // https://stackoverflow.com/questions/3543187/prepending-http-to-a-url-that-doesnt-already-contain-http
+  if (websiteFormatted.indexOf('://') === -1 && websiteFormatted.indexOf('mailto:') === -1) {
+    websiteFormatted = 'http://' + websiteFormatted;
+  }
+
+  return websiteFormatted;
+}
+
 function RequirementTag({
   requirementList,
   beforeLabel,
@@ -139,8 +151,8 @@ export default function AirTableCard({ location }) {
     address = null;
   }
 
-  const website = location.fields["Website"]
-    ? location.fields["Website"].trim()
+  let website = location.fields["Website"]
+    ? formatWebsite(location.fields["Website"])
     : null;
 
   const reportNoteList = location.fields["Latest report notes"];

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -56,17 +56,29 @@ export default function Footer() {
           </a>
         </div>
         <div className="mx-auto text-center my-3">
-            <a href="?lang=en#googtrans(en|en)" className="notranslate" data-lang="en">
-              English
-            </a>
-            {" · "}
-            <a href="?lang=es#googtrans(en|es)" className="notranslate" data-lang="es">
-              Español
-            </a>
-            {" · "}
-            <a href="?lang=zh#googtrans(en|zh-CN)" className="notranslate" data-lang="zh">
-              简体中文
-            </a>
+          <a
+            href="?lang=en#googtrans(en|en)"
+            className="notranslate"
+            data-lang="en"
+          >
+            English
+          </a>
+          {" · "}
+          <a
+            href="?lang=es#googtrans(en|es)"
+            className="notranslate"
+            data-lang="es"
+          >
+            Español
+          </a>
+          {" · "}
+          <a
+            href="?lang=zh#googtrans(en|zh-CN)"
+            className="notranslate"
+            data-lang="zh"
+          >
+            简体中文
+          </a>
         </div>
         <div className="mx-auto text-center my-3">
           <div id="google_translate_element"></div>

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -55,6 +55,22 @@ export default function Footer() {
             <AiFillInstagram size="1.75em" />
           </a>
         </div>
+        <div className="mx-auto text-center my-3">
+            <a href="?lang=en#googtrans(en|en)" className="notranslate" data-lang="en">
+              English
+            </a>
+            {" · "}
+            <a href="?lang=es#googtrans(en|es)" className="notranslate" data-lang="es">
+              Español
+            </a>
+            {" · "}
+            <a href="?lang=zh#googtrans(en|zh-CN)" className="notranslate" data-lang="zh">
+              简体中文
+            </a>
+        </div>
+        <div className="mx-auto text-center my-3">
+          <div id="google_translate_element"></div>
+        </div>
         <p className="text-center">
           Made with {HeartIcon} by volunteer Pennsylvanians and others.
         </p>

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -84,7 +84,10 @@ export default function Footer() {
               简体中文
             </a>
           </div>
-          <div className="mt-3 mx-auto mx-sm-0 mt-sm-0" id="google_translate_element"></div>
+          <div
+            className="mt-3 mx-auto mx-sm-0 mt-sm-0"
+            id="google_translate_element"
+          ></div>
         </div>
         <p className="text-center">
           <a

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -55,37 +55,37 @@ export default function Footer() {
             <AiFillInstagram size="1.75em" />
           </a>
         </div>
-        <div className="mx-auto text-center my-3">
-          <a
-            href="?lang=en#googtrans(en|en)"
-            className="notranslate"
-            data-lang="en"
-          >
-            English
-          </a>
-          {" · "}
-          <a
-            href="?lang=es#googtrans(en|es)"
-            className="notranslate"
-            data-lang="es"
-          >
-            Español
-          </a>
-          {" · "}
-          <a
-            href="?lang=zh#googtrans(en|zh-CN)"
-            className="notranslate"
-            data-lang="zh"
-          >
-            简体中文
-          </a>
-        </div>
-        <div className="mx-auto text-center my-3">
-          <div id="google_translate_element"></div>
-        </div>
         <p className="text-center">
           Made with {HeartIcon} by volunteer Pennsylvanians and others.
         </p>
+        <div className="my-3 d-flex flex-column flex-sm-row justify-content-center">
+          <div className="align-self-center text-center px-sm-4">
+            <a
+              href="?lang=en#googtrans(en|en)"
+              className="notranslate"
+              data-lang="en"
+            >
+              English
+            </a>
+            {" · "}
+            <a
+              href="?lang=es#googtrans(en|es)"
+              className="notranslate"
+              data-lang="es"
+            >
+              Español
+            </a>
+            {" · "}
+            <a
+              href="?lang=zh#googtrans(en|zh-CN)"
+              className="notranslate"
+              data-lang="zh"
+            >
+              简体中文
+            </a>
+          </div>
+          <div className="mt-3 mx-auto mx-sm-0 mt-sm-0" id="google_translate_element"></div>
+        </div>
         <p className="text-center">
           <a
             target="_blank"

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,6 +5,9 @@ import "nprogress/nprogress.css";
 import Router from "next/router";
 import Head from "next/head";
 import NProgress from "nprogress";
+import patchDOMForGoogleTranslate from '../utils/patchDOMForGoogleTranslate';
+
+patchDOMForGoogleTranslate();
 
 // Configure loading progress bar
 NProgress.configure({ showSpinner: true });
@@ -93,6 +96,24 @@ function MyApp({ Component, pageProps }) {
           name="twitter:image:alt"
           content="Find vaccines in Pennsylvania with our volunteer-run site"
         />
+        
+        <script
+          type="text/javascript"
+          dangerouslySetInnerHTML={{
+            __html: `
+              function googleTranslateElementInit() {
+                new google.translate.TranslateElement({pageLanguage: 'en'}, 'google_translate_element');
+              }
+            `
+          }}
+        ></script>
+      
+        <script
+          type="text/javascript"
+          src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"
+        ></script>
+
+        <link type="text/css" rel="stylesheet" charSet="UTF-8" href="https://translate.googleapis.com/translate_static/css/translateelement.css"/>
       </Head>
       <main className="d-flex flex-column h-100">
         <Component {...pageProps} />

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,7 +5,7 @@ import "nprogress/nprogress.css";
 import Router from "next/router";
 import Head from "next/head";
 import NProgress from "nprogress";
-import patchDOMForGoogleTranslate from '../utils/patchDOMForGoogleTranslate';
+import patchDOMForGoogleTranslate from "../utils/patchDOMForGoogleTranslate";
 
 patchDOMForGoogleTranslate();
 
@@ -96,7 +96,7 @@ function MyApp({ Component, pageProps }) {
           name="twitter:image:alt"
           content="Find vaccines in Pennsylvania with our volunteer-run site"
         />
-        
+
         <script
           type="text/javascript"
           dangerouslySetInnerHTML={{
@@ -104,16 +104,21 @@ function MyApp({ Component, pageProps }) {
               function googleTranslateElementInit() {
                 new google.translate.TranslateElement({pageLanguage: 'en'}, 'google_translate_element');
               }
-            `
+            `,
           }}
         ></script>
-      
+
         <script
           type="text/javascript"
           src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"
         ></script>
 
-        <link type="text/css" rel="stylesheet" charSet="UTF-8" href="https://translate.googleapis.com/translate_static/css/translateelement.css"/>
+        <link
+          type="text/css"
+          rel="stylesheet"
+          charSet="UTF-8"
+          href="https://translate.googleapis.com/translate_static/css/translateelement.css"
+        />
       </Head>
       <main className="d-flex flex-column h-100">
         <Component {...pageProps} />

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,26 +1,46 @@
-import { createRef, useCallback } from "react";
+import { createRef } from "react";
 import InTheMedia from "../components/InTheMedia";
 import CountySuggestion from "../components/CountySuggestion";
 import CountySearch from "../components/CountySearch";
 import Layout from "../layouts/Layout";
 import Image from "next/image";
-import { FaTwitter, FaFacebook } from "react-icons/fa";
+import { FaTwitter, FaFacebook, FaAngleDoubleDown } from "react-icons/fa";
 import { AiFillInstagram } from "react-icons/ai";
 
 export default function Index() {
   const countySearchRef = createRef();
 
-  const onClickFindCounty = useCallback(() => {
-    if (countySearchRef.current) {
-      countySearchRef.current.focus();
-    }
-
-    return false;
-  }, [countySearchRef]);
-
   return (
     <Layout title="Vaccine Availability">
-      <div className="mt-4">
+      <div className="mt-3">
+        <div className="text-center text-sm-right mr-sm-4">
+          <a
+            href="?lang=en#googtrans(en|en)"
+            className="notranslate"
+            data-lang="en"
+          >
+            English
+          </a>
+          {" · "}
+          <a
+            href="?lang=es#googtrans(en|es)"
+            className="notranslate"
+            data-lang="es"
+          >
+            Español
+          </a>
+          {" · "}
+          <a
+            href="?lang=zh#googtrans(en|zh-CN)"
+            className="notranslate"
+            data-lang="zh"
+          >
+            简体中文
+          </a>
+          <a href="#google_translate_element" className="ml-1">
+            <FaAngleDoubleDown />
+          </a>
+        </div>
         <div id="landing-header">
           <div className="container-fluid">
             <h1 className="text-center" id="landing-title">
@@ -84,7 +104,7 @@ export default function Index() {
       </div>
       <style jsx>{`
         #landing-header {
-          margin-top: 40px;
+          margin-top: 15px;
           margin-bottom: 80px;
         }
 

--- a/utils/patchDOMForGoogleTranslate.js
+++ b/utils/patchDOMForGoogleTranslate.js
@@ -2,37 +2,37 @@
 // See https://github.com/facebook/react/issues/11538#issuecomment-417504600
 
 export default function patchDOMForGoogleTranslate() {
-    if (typeof Node === 'function' && Node.prototype) {
-        const originalRemoveChild = Node.prototype.removeChild;
-        // $FlowFixMe Intentionally monkepatching.
-        Node.prototype.removeChild = function(child) {
-        if (child.parentNode !== this) {
-            if (typeof console !== 'undefined') {
-            console.error(
-                'Cannot remove a child from a different parent',
-                child,
-                this,
-            );
-            }
-            return child;
+  if (typeof Node === "function" && Node.prototype) {
+    const originalRemoveChild = Node.prototype.removeChild;
+    // $FlowFixMe Intentionally monkepatching.
+    Node.prototype.removeChild = function (child) {
+      if (child.parentNode !== this) {
+        if (typeof console !== "undefined") {
+          console.error(
+            "Cannot remove a child from a different parent",
+            child,
+            this
+          );
         }
-        return originalRemoveChild.apply(this, arguments);
-        };
-    
-        const originalInsertBefore = Node.prototype.insertBefore;
-        // $FlowFixMe Intentionally monkepatching.
-        Node.prototype.insertBefore = function(newNode, referenceNode) {
-        if (referenceNode && referenceNode.parentNode !== this) {
-            if (typeof console !== 'undefined') {
-            console.error(
-                'Cannot insert before a reference node from a different parent',
-                referenceNode,
-                this,
-            );
-            }
-            return newNode;
+        return child;
+      }
+      return originalRemoveChild.apply(this, arguments);
+    };
+
+    const originalInsertBefore = Node.prototype.insertBefore;
+    // $FlowFixMe Intentionally monkepatching.
+    Node.prototype.insertBefore = function (newNode, referenceNode) {
+      if (referenceNode && referenceNode.parentNode !== this) {
+        if (typeof console !== "undefined") {
+          console.error(
+            "Cannot insert before a reference node from a different parent",
+            referenceNode,
+            this
+          );
         }
-        return originalInsertBefore.apply(this, arguments);
-        };
-    }
+        return newNode;
+      }
+      return originalInsertBefore.apply(this, arguments);
+    };
   }
+}

--- a/utils/patchDOMForGoogleTranslate.js
+++ b/utils/patchDOMForGoogleTranslate.js
@@ -1,0 +1,38 @@
+// This is not pretty.
+// See https://github.com/facebook/react/issues/11538#issuecomment-417504600
+
+export default function patchDOMForGoogleTranslate() {
+    if (typeof Node === 'function' && Node.prototype) {
+        const originalRemoveChild = Node.prototype.removeChild;
+        // $FlowFixMe Intentionally monkepatching.
+        Node.prototype.removeChild = function(child) {
+        if (child.parentNode !== this) {
+            if (typeof console !== 'undefined') {
+            console.error(
+                'Cannot remove a child from a different parent',
+                child,
+                this,
+            );
+            }
+            return child;
+        }
+        return originalRemoveChild.apply(this, arguments);
+        };
+    
+        const originalInsertBefore = Node.prototype.insertBefore;
+        // $FlowFixMe Intentionally monkepatching.
+        Node.prototype.insertBefore = function(newNode, referenceNode) {
+        if (referenceNode && referenceNode.parentNode !== this) {
+            if (typeof console !== 'undefined') {
+            console.error(
+                'Cannot insert before a reference node from a different parent',
+                referenceNode,
+                this,
+            );
+            }
+            return newNode;
+        }
+        return originalInsertBefore.apply(this, arguments);
+        };
+    }
+  }


### PR DESCRIPTION
#### Description
Adds basic google translate functionality with a few notable caveats mentioned below.

Includes the top 3 languages in PA (english, spansish, chinese) on every page, as well as an all language dropdown in certain situations.

TODO: Should we make these available further up the page or are we ok with it just in the footer?

Caveats:
1. The google translate widget is pretty old (and was only un-deprecated because of covid), and does not work well with React. I've implemented a patch from the below link to make this work for now. The potential tradeoff is making react _slightly_ slower, but in my testing I haven't noticed any slowdown, and I think the value added by this functionality > any tiny performance hits. This is documented extensively here: https://github.com/facebook/react/issues/11538#issuecomment-417504600 
2. The widget wasn't really built for modern web apps. The javascript loaded in the head targets a div we can place anywhere, and renders the dropdown button in the div on page load. This is an issue when switching between pages because the footer div often reloads itself, but the script doesn't re-run to replace the dropdown, causing it to sometimes be missing in the footer. As a workaround, the specific language links are always visible, and the dropdown is always visible on initial page load. We could probably fix this by actively retriggering the JS on page change, but I haven't had time to implement this. For what it's worth, I've noticed this is also an issue in a few other vaccine sites using this widget, notably https://nycvaccinelist.com

#### Tests
- [x] Translation links work
- [x] Translation links remain in their native languages

#### Screenshots
<img width="590" alt="Screen Shot 2021-03-01 at 4 45 02 PM" src="https://user-images.githubusercontent.com/3207842/109566547-06b19200-7ab2-11eb-9433-a8f410e384a7.png">
